### PR TITLE
chore: add servicesIndexRaw content in case catch block is called during getResourceUrl

### DIFF
--- a/lib/modules/datasource/nuget/v3.ts
+++ b/lib/modules/datasource/nuget/v3.ts
@@ -90,8 +90,8 @@ export async function getResourceUrl(
       throw err;
     }
     logger.debug(
-      { err, url },
-      `nuget registry failure: can't get ${resourceType} of servicesIndexRaw ${servicesIndexRaw}`
+      { err, url, servicesIndexRaw },
+      `nuget registry failure: can't get ${resourceType}`
     );
     return null;
   }

--- a/lib/modules/datasource/nuget/v3.ts
+++ b/lib/modules/datasource/nuget/v3.ts
@@ -35,10 +35,10 @@ export async function getResourceUrl(
   if (cachedResult) {
     return cachedResult;
   }
-
+  let servicesIndexRaw: ServicesIndexRaw | undefined;
   try {
     const responseCacheKey = url;
-    let servicesIndexRaw = await packageCache.get<ServicesIndexRaw>(
+    servicesIndexRaw = await packageCache.get<ServicesIndexRaw>(
       cacheNamespace,
       responseCacheKey
     );
@@ -91,7 +91,7 @@ export async function getResourceUrl(
     }
     logger.debug(
       { err, url },
-      `nuget registry failure: can't get ${resourceType}`
+      `nuget registry failure: can't get ${resourceType} of servicesIndexRaw ${servicesIndexRaw}`
     );
     return null;
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

For more details have a look into this discussion https://github.com/renovatebot/renovate/discussions/25054. 
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
