### PR TITLE
feat(manager/apm): support digest pinning for SHA-pinned deps

### DIFF
--- a/lib/modules/manager/apm/extract.spec.ts
+++ b/lib/modules/manager/apm/extract.spec.ts
@@ -51,19 +51,54 @@ describe('modules/manager/apm/extract', () => {
             datasource: GithubTagsDatasource.id,
             packageName: 'microsoft/apm-sample-package',
             replaceString: 'microsoft/apm-sample-package#v1.0.0',
-            autoReplaceStringTemplate: '{{depName}}#{{newValue}}',
+            autoReplaceStringTemplate:
+              '{{depName}}#{{#if newDigest}}{{newDigest}} # {{newValue}}{{else}}{{newValue}}{{/if}}',
           },
         ],
       });
     });
 
-    it('skips SHA-pinned entries (tag comment is stripped by YAML)', () => {
-      // APM documents `owner/repo#<sha> # v2.0.0`, but the trailing tag is a
-      // YAML comment that parsing strips, so the entry arrives as a bare SHA.
+    it('parses the SHA-pinned digest form (tag recovered from comment)', () => {
       const content = codeBlock`
         dependencies:
           apm:
+            - owner/tool#v1.0.0
             - acme/playbooks#b1c2d3e4f5a6b7c8d9e0f1234567890abcdef123 # v2.0.0
+      `;
+      expect(extractPackageFile(content, packageFile)?.deps).toMatchObject([
+        { depName: 'owner/tool', currentValue: 'v1.0.0' },
+        {
+          depName: 'acme/playbooks',
+          packageName: 'acme/playbooks',
+          datasource: GithubTagsDatasource.id,
+          currentDigest: 'b1c2d3e4f5a6b7c8d9e0f1234567890abcdef123',
+          currentValue: 'v2.0.0',
+          replaceString:
+            'acme/playbooks#b1c2d3e4f5a6b7c8d9e0f1234567890abcdef123 # v2.0.0',
+        },
+      ]);
+    });
+
+    it('skips a bare SHA with no tag comment', () => {
+      const content = codeBlock`
+        dependencies:
+          apm:
+            - acme/playbooks#b1c2d3e4f5a6b7c8d9e0f1234567890abcdef123
+      `;
+      expect(extractPackageFile(content, packageFile)?.deps).toMatchObject([
+        {
+          depName: 'acme/playbooks',
+          currentDigest: 'b1c2d3e4f5a6b7c8d9e0f1234567890abcdef123',
+          skipReason: 'unversioned-reference',
+        },
+      ]);
+    });
+
+    it('skips a quoted SHA-pin (exact text not recoverable)', () => {
+      const content = codeBlock`
+        dependencies:
+          apm:
+            - "acme/playbooks#b1c2d3e4f5a6b7c8d9e0f1234567890abcdef123" # v2.0.0
       `;
       expect(extractPackageFile(content, packageFile)?.deps).toMatchObject([
         {
@@ -289,7 +324,8 @@ describe('modules/manager/apm/extract', () => {
           datasource: GithubTagsDatasource.id,
           packageName: 'owner/repo',
           replaceString: 'owner/repo#v1.0.0',
-          autoReplaceStringTemplate: '{{depName}}#{{newValue}}',
+          autoReplaceStringTemplate:
+            '{{depName}}#{{#if newDigest}}{{newDigest}} # {{newValue}}{{else}}{{newValue}}{{/if}}',
         },
       ]);
     });

--- a/lib/modules/manager/apm/extract.ts
+++ b/lib/modules/manager/apm/extract.ts
@@ -52,6 +52,20 @@ function determineDatasource(
 /** A full commit SHA (git sha1 or sha256). */
 const shaRegex = regEx(/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/i);
 
+const newlineRegex = regEx(/\r?\n/);
+
+/** A trailing ` # <tag>` comment on a manifest line. */
+const commentTagRegex = regEx(/^\s+#\s*(?<tag>\S.*?)\s*$/);
+
+/**
+ * Renders both `owner/repo#<tag>` and the digest-pinned
+ * `owner/repo#<sha> # <tag>` form, mirroring the github-actions
+ * `uses: owner/action@<sha> # v4` behaviour so `pinDigests` can pin a bare tag
+ * to a SHA and keep the trailing tag comment current.
+ */
+const autoReplaceStringTemplate =
+  '{{depName}}#{{#if newDigest}}{{newDigest}} # {{newValue}}{{else}}{{newValue}}{{/if}}';
+
 /**
  * APM virtual-package subpaths (skills/prompts/etc.) begin at one of these
  * "primitive" directories or at a file with a virtual extension. APM only uses
@@ -93,20 +107,52 @@ function resolveRepoPath(
 }
 
 /**
+ * APM keeps the release tag for a SHA-pinned dependency in a trailing YAML
+ * comment (`owner/repo#<sha> # v2.0.0`), which the structured parse strips. Scan
+ * the raw manifest for the (unquoted) entry to recover the tag as `currentValue`
+ * and the exact text to replace, so `pinDigests` can update both the SHA and the
+ * tag. Returns `undefined` for a bare SHA (no tag comment) or a form we can't
+ * recover verbatim (e.g. quoted), which the caller then skips.
+ */
+function findPinnedTail(
+  content: string,
+  value: string,
+): { replaceString: string; currentValue: string } | undefined {
+  for (const line of content.split(newlineRegex)) {
+    const item = line.trimStart();
+    if (!item.startsWith('-')) {
+      continue;
+    }
+    const afterDash = item.slice(1).trimStart();
+    if (!afterDash.startsWith(value)) {
+      continue;
+    }
+    const tail = commentTagRegex.exec(afterDash.slice(value.length));
+    if (!tail?.groups?.tag) {
+      return undefined;
+    }
+    return {
+      replaceString: afterDash.trimEnd(),
+      currentValue: tail.groups.tag,
+    };
+  }
+  return undefined;
+}
+
+/**
  * Parse a single APM dependency string of the form
  * `[host/]owner/repo[/subpath...][#<ref>]`, where `<ref>` is a semver tag/range,
  * a branch, or a commit SHA.
  *
- * APM documents pinning to a commit SHA with the release tag kept as a trailing
- * YAML comment (`owner/repo#<sha> # v2.0.0`). YAML parsing strips that comment,
- * so the tag isn't visible here; such entries are skipped rather than treating
- * the SHA as a version (which no `*-tags` datasource can resolve) or rewriting
- * it. Keeping SHA-pinned entries current would need `pinDigests`/digest support
- * built on a comment-preserving parse - a larger, separate change.
+ * For a SHA-pinned entry the release tag lives in a trailing YAML comment; when
+ * present it is recovered from `content` so the entry updates as a digest
+ * (`currentDigest` + `currentValue`). A bare SHA with no tag comment has no
+ * version to track and is skipped.
  */
 export function parseApmDependency(
   entry: string,
   depType: string,
+  content: string,
 ): PackageDependency {
   const hashIndex = entry.indexOf('#');
   const pathPart = hashIndex === -1 ? entry : entry.slice(0, hashIndex);
@@ -142,34 +188,51 @@ export function parseApmDependency(
     };
   }
 
-  if (shaRegex.test(ref)) {
-    // SHA-pinned entry - recognized and left intact (see note above).
-    return { ...base, currentDigest: ref, skipReason: 'unversioned-reference' };
-  }
-
   const { datasource, packageName, registryUrls } = determineDatasource(
     host,
     platform,
     repoPath,
   );
-
-  return {
+  const dep: PackageDependency = {
     ...base,
-    currentValue: ref,
     datasource,
     packageName,
     ...(registryUrls ? { registryUrls } : {}),
+    autoReplaceStringTemplate,
+  };
+
+  if (shaRegex.test(ref)) {
+    const tail = findPinnedTail(content, entry);
+    if (!tail) {
+      // Bare SHA with no recoverable tag comment - no version to track.
+      return {
+        ...base,
+        currentDigest: ref,
+        skipReason: 'unversioned-reference',
+      };
+    }
+    return {
+      ...dep,
+      currentValue: tail.currentValue,
+      currentDigest: ref,
+      replaceString: tail.replaceString,
+    };
+  }
+
+  return {
+    ...dep,
+    currentValue: ref,
     replaceString: entry,
-    autoReplaceStringTemplate: '{{depName}}#{{newValue}}',
   };
 }
 
 function extractSection(
   entries: string[] | undefined,
   depType: string,
+  content: string,
 ): PackageDependency[] {
   return coerceArray(entries).map((entry) =>
-    parseApmDependency(entry, depType),
+    parseApmDependency(entry, depType, content),
   );
 }
 
@@ -186,8 +249,8 @@ export function extractPackageFile(
   }
 
   const deps = [
-    ...extractSection(manifest.dependencies?.apm, 'apm'),
-    ...extractSection(manifest.devDependencies?.apm, 'apm-dev'),
+    ...extractSection(manifest.dependencies?.apm, 'apm', content),
+    ...extractSection(manifest.devDependencies?.apm, 'apm-dev', content),
   ];
 
   if (!deps.length) {

--- a/lib/modules/manager/apm/readme.md
+++ b/lib/modules/manager/apm/readme.md
@@ -18,5 +18,9 @@ devDependencies:
 Only entries that pin an exact `#<ref>` are updated.
 Entries without a `#<ref>` are skipped because there is no version to bump.
 
+APM also documents pinning to a commit SHA with the release tag kept as a trailing comment (`owner/repo#<sha> # v2.0.0`).
+With `pinDigests` enabled (part of the `config:best-practices` preset) Renovate keeps both the SHA and the tag comment current, the same way it does for `github-actions` (`uses: owner/action@<sha> # v4`).
+A SHA pin without a tag comment is skipped, as there is no version to track.
+
 When an `apm.lock.yaml` lockfile is present, Renovate refreshes it by running `apm install` after updating the manifest.
 This requires the `apm` CLI to be available (for example, with `binarySource=global`).


### PR DESCRIPTION
Fork-local PR for **isolated review** of the SHA-digest-pinning work before deciding whether to fold it into the upstream apm-manager PR (#44390). Base is the upstream PR branch, so nothing here force-pushes or mangles that branch — if this looks good we merge it forward; if not, we close it.

## What this adds

Option A from the PR discussion (vlsi): support the documented SHA-pinned form and keep it current via `pinDigests`, the same way the `github-actions` manager does for `uses: owner/action@<sha> # v4`.

APM documents pinning a commit SHA with the release tag kept as a **trailing YAML comment**:

```yaml
dependencies:
  apm:
    - acme/playbooks#b1c2d3e4f5a6b7c8d9e0f1234567890abcdef123 # v2.0.0
```

The catch (and why this wasn't trivial): a normal YAML parse **strips that comment**, so the tag never reaches the manager. This change scans the raw manifest to recover the tag + the exact text to replace, then emits `currentDigest` + `currentValue` with a digest-aware `autoReplaceStringTemplate` (`{{depName}}#{{newDigest}} # {{newValue}}`). Structured parsing (the zod schema) still drives which entries exist; only the SHA-pin enrichment reads raw lines.

## Behaviour

- `owner/repo#<sha> # v2.0.0` → digest update (SHA + tag both kept current).
- `owner/repo#v1.0.0` → tag update as before; with `pinDigests` it can pin to `#<sha> # v1.0.0`.
- Bare `owner/repo#<sha>` (no tag comment) → skipped (`unversioned-reference`); nothing to track.
- Quoted SHA-pin (`- "owner/repo#<sha>" # v2.0.0`) → skipped; we can't rewrite it verbatim. (Rare; documented as a known limitation.)

## Notes / things to check

- Whitespace between the SHA and `#` is normalized to a single space on update (matches github-actions' default). Flag if you'd rather preserve it.
- `git-tags` (non-github/gitlab hosts) may lack `getDigest`, so digest updates there are best-effort.
- 82 tests, 100% coverage on the module; `type-check`, oxlint, biome, prettier, markdown-lint all clean.

Not for upstream yet — pending the SHA-direction discussion on #44390.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbMAQBiMRNkCNxc8EGQw1C)_