### PR TITLE
fix(preset): pinGitHubActionDigestsToSemver should pin digests

### DIFF
--- a/lib/config/presets/internal/helpers.preset.spec.ts
+++ b/lib/config/presets/internal/helpers.preset.spec.ts
@@ -1,0 +1,45 @@
+import { resolveConfigPresets } from '../index.ts';
+import { presets } from './helpers.preset.ts';
+
+describe('config/presets/internal/helpers.preset', () => {
+  describe('pinGitHubActionDigestsToSemver', () => {
+    it('resolves to package rules that pin digests and apply semver', async () => {
+      const { config } = await resolveConfigPresets({
+        extends: ['helpers:pinGitHubActionDigestsToSemver'],
+      });
+
+      // No nested `packageRules` should leak into an individual rule.
+      for (const rule of config.packageRules!) {
+        expect(rule).not.toHaveProperty('packageRules');
+      }
+
+      // `pinDigests` must be applied to `action` deps.
+      expect(config.packageRules).toContainEqual(
+        expect.objectContaining({
+          matchDepTypes: ['action'],
+          pinDigests: true,
+        }),
+      );
+
+      // The semver `extractVersion`/`versioning` must be scoped to `action`
+      // deps, not applied unconditionally.
+      expect(config.packageRules).toContainEqual(
+        expect.objectContaining({
+          matchDepTypes: ['action'],
+          extractVersion: '^(?<version>v?\\d+\\.\\d+\\.\\d+)$',
+          versioning:
+            'regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$',
+        }),
+      );
+    });
+
+    it('does not define package rules with an unconditional versioning', () => {
+      const preset = presets.pinGitHubActionDigestsToSemver;
+      for (const rule of preset.packageRules!) {
+        if (rule.versioning ?? rule.extractVersion) {
+          expect(rule.matchDepTypes).toEqual(['action']);
+        }
+      }
+    });
+  });
+});

--- a/lib/config/presets/internal/helpers.preset.ts
+++ b/lib/config/presets/internal/helpers.preset.ts
@@ -126,10 +126,11 @@ export const presets: Record<string, Preset> = {
   },
   pinGitHubActionDigestsToSemver: {
     description: 'Convert pinned GitHub Action digests to SemVer.',
+    extends: ['helpers:pinGitHubActionDigests'],
     packageRules: [
       {
-        extends: ['helpers:pinGitHubActionDigests'],
         extractVersion: '^(?<version>v?\\d+\\.\\d+\\.\\d+)$',
+        matchDepTypes: ['action'],
         versioning:
           'regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$',
       },


### PR DESCRIPTION
## Changes

The `helpers:pinGitHubActionDigestsToSemver` preset nested `extends: ['helpers:pinGitHubActionDigests']` **inside a single `packageRules` entry**. When the preset resolver merged the extended preset into that rule, the result was a package rule that contained a nested `packageRules` property (which is invalid at the rule level and silently dropped), so `pinDigests: true` was never applied through this preset. At the same time, `extractVersion` and `versioning` ended up applied unconditionally, with no `matchDepTypes` matcher.

Resolving the old preset produced:

```jsonc
"packageRules": [
  {
    "packageRules": [ { "matchDepTypes": ["action"], "pinDigests": true } ], // dropped
    "extractVersion": "…",   // applied to everything, no matcher
    "versioning": "…"
  }
]
```

This PR moves the `extends` to the preset level and scopes the SemVer `extractVersion`/`versioning` to `action` deps via `matchDepTypes`. It now resolves to two correctly-scoped rules:

```jsonc
"packageRules": [
  { "matchDepTypes": ["action"], "pinDigests": true },
  { "matchDepTypes": ["action"], "extractVersion": "…", "versioning": "…" }
]
```

A regression test (`helpers.preset.spec.ts`) asserts that no resolved rule leaks a nested `packageRules`, and that both `pinDigests` and the SemVer `extractVersion`/`versioning` are present and scoped to `action`.

> [!NOTE]
> This is deliberately narrow. It fixes the preset definition itself. It does **not** change the separate, discussed behaviour where pinning a coarse tag (e.g. `v1`) keeps the loose comment `# v1` instead of normalising it to the fully-qualified `# v1.0.0` — that requires a core lookup change and is being discussed separately.

## Context

Related to discussion https://github.com/renovatebot/renovate/discussions/27194 (this is a Discussion, not an Issue).

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance: root-cause analysis, the preset change, and the added unit test were produced with Claude Code (Anthropic).

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

- [x] Newly added/modified unit tests

Verified by resolving `helpers:pinGitHubActionDigestsToSemver` via `resolveConfigPresets` before/after, and by the new spec + the existing `internal/index.spec.ts` preset-validation suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRg2mEPmoeYoxRoKdegDs5)_